### PR TITLE
Unquote username and password during mysql uri parse

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,10 +52,10 @@ test: $(generated)
 
 .ONESHELL: systest
 systest:
-	docker-compose -f docker-compose.test.yaml up -d --build && \
-	docker-compose -f docker-compose.test.yaml run test python -m pytest -v test/sys/; \
+	docker compose -f docker-compose.test.yaml up -d --build && \
+	docker compose -f docker-compose.test.yaml run test python -m pytest -v test/sys/; \
 	code=$$? && \
-	docker-compose -f docker-compose.test.yaml down --rmi all --remove-orphans --volumes && \
+	docker compose -f docker-compose.test.yaml down --rmi all --remove-orphans --volumes && \
 	exit $$code
 
 clean:

--- a/test/unit/test_utils.py
+++ b/test/unit/test_utils.py
@@ -100,12 +100,12 @@ def test_mysql_connection_info_from_uri(uri: str, exception_class: Optional[Type
 @mark.parametrize(
     "uri, expected",
     [
-        ("mysql://<user>:<pwd>@<ip>:1234/", "mysql://<user>:<pwd>@<ip>:1234/?ssl-mode=REQUIRED"),
-        ("mysql://<user>:<pwd>@<ip>:1234/?", "mysql://<user>:<pwd>@<ip>:1234/?ssl-mode=REQUIRED"),
-        ("mysql://<user>:<pwd>@<ip>:1234/?ssl-mode=DISABLED", "mysql://<user>:<pwd>@<ip>:1234/?ssl-mode=DISABLED"),
-        ("mysql://<user>:<pwd>@<ip>:1234/?ssl-mode=REQUIRED", "mysql://<user>:<pwd>@<ip>:1234/?ssl-mode=REQUIRED"),
+        ("mysql://user:pwd@<ip>:1234/", "mysql://user:pwd@<ip>:1234/?ssl-mode=REQUIRED"),
+        ("mysql://user:pwd@<ip>:1234/?", "mysql://user:pwd@<ip>:1234/?ssl-mode=REQUIRED"),
+        ("mysql://user:pwd@<ip>:1234/?ssl-mode=DISABLED", "mysql://user:pwd@<ip>:1234/?ssl-mode=DISABLED"),
+        ("mysql://user:pwd@<ip>:1234/?ssl-mode=REQUIRED", "mysql://user:pwd@<ip>:1234/?ssl-mode=REQUIRED"),
         # previously documented legacy value
-        ("mysql://<user>:<pwd>@<ip>:1234/?ssl-mode=DISABLE", "mysql://<user>:<pwd>@<ip>:1234/?ssl-mode=DISABLED"),
+        ("mysql://user:pwd@<ip>:1234/?ssl-mode=DISABLE", "mysql://user:pwd@<ip>:1234/?ssl-mode=DISABLED"),
     ],
 )
 def test_mysql_connection_info_to_uri(uri: str, expected: str) -> None:
@@ -136,3 +136,11 @@ def test_mysql_connection_info_from_uri_password_length(
             MySQLConnectionInfo.from_uri(uri)
     else:
         MySQLConnectionInfo.from_uri(uri)
+
+
+def test_mysql_connection_info_from_uri_unquote_username_and_password() -> None:
+    uri = "mysql://test%40example.com:%40%26%20%7B@<ip>:1234/?ssl-mode=DISABLED"
+    conn_info = MySQLConnectionInfo.from_uri(uri)
+    assert conn_info.username == "test@example.com"
+    assert conn_info.password == "@& {"
+    assert conn_info.to_uri() == uri


### PR DESCRIPTION
It's necessary to encode/decode username and password in URI. Otherwise it's impossible to use special symbols ('@', ':') in these parts.

Also [docker compose V1 is deprecated](https://github.blog/changelog/2024-04-10-github-hosted-runner-images-deprecation-notice-docker-compose-v1/) using V2 instead.
```
Run make && make systest
...
exit $code
/bin/sh: 1: docker-compose: not found
/bin/sh: 4: docker-compose: not found
make: *** [Makefile:[5](https://github.com/Aiven-Open/aiven-mysql-migrate/pull/34/checks#step:3:6)5: systest] Error 127
Error: Process completed with exit code 2.
```