### PR TITLE
Force SSL_MODE_REQUIRED when setting up replication CHANGE MASTER TO

### DIFF
--- a/aiven_mysql_migrate/migration.py
+++ b/aiven_mysql_migrate/migration.py
@@ -400,7 +400,8 @@ class MySQLMigration:
         with self.target_master.cur() as cur:
             query = (
                 "CHANGE MASTER TO MASTER_HOST = %s, MASTER_PORT = %s, MASTER_USER = %s, MASTER_PASSWORD = %s, "
-                f"MASTER_AUTO_POSITION = 1, MASTER_SSL = {1 if self.source.ssl else 0}"
+                f"MASTER_AUTO_POSITION = 1, MASTER_SSL = {1 if self.source.ssl else 0}, "
+                "MASTER_SSL_VERIFY_SERVER_CERT = 0, MASTER_SSL_CA = '', MASTER_SSL_CAPATH = ''"
             )
             if LooseVersion(self.target.version) >= LooseVersion("8.0.19"):
                 query += ", REQUIRE_ROW_FORMAT = 1"


### PR DESCRIPTION
If we set `MASTER_SSL = 0`, mysqld would not evaluate any of the other `MASTER_SSL_*` settings and we turn off TLS.

But in case of `MASTER_SSL = 1`, we want to reset every setting to

```
MASTER_SSL_VERIFY_SERVER_CERT = 0
MASTER_SSL_CA = ''
MASTER_SSL_CAPATH = ''
```

so that `mysqld` would deterministically create a replication channel with `SSL_MODE_REQUIRED`, matching `--ssl-mode=REQUIRED` for `mysql` and `mysqldump`. The logic is defined here:
https://github.com/mysql/mysql-server/blob/ff05628a530696bc6851ba6540ac250c7a059aa7/sql/rpl_replica.cc#L8377-L8382

The reason is that `mysqld` may have previously been set up with a replication channel that had stricter `MASTER_SSL_*` settings configured, and this means `mysqld` would re-use the stricter settings when not explicitly turned off.

Observe: [`change_master_cmd`](https://github.com/mysql/mysql-server/blob/6ba1fef58b043ac5e9657ded777d20619b9b2f4e/sql/rpl_replica.cc#L11065-L11077) is always re-using a previously used `Master_info` from the `channel_map`, thus `mysqld` will re-use the settings from `Master_info` in [`change_receive_options`](https://github.com/mysql/mysql-server/blob/6ba1fef58b043ac5e9657ded777d20619b9b2f4e/sql/rpl_replica.cc#L9652-L9672) whenever they are not explictly set to some
value (`LEX_MASTER_INFO::LEX_MI_UNCHANGED`).

See [Setting Up Replication to Use Encrypted Connections (5.7)](https://dev.mysql.com/doc/mysql-replication-excerpt/5.7/en/replication-encrypted-connections.html), [CHANGE MASTER TO Statement (5.7)](https://dev.mysql.com/doc/refman/5.7/en/change-master-to.html), [Setting Up Replication to Use Encrypted Connections (8.0)](https://dev.mysql.com/doc/refman/8.0/en/replication-encrypted-connections.html), and [CHANGE REPLICATION SOURCE TO Statement (8.0)](https://dev.mysql.com/doc/refman/8.0/en/change-replication-source-to.html).